### PR TITLE
Decompress compressed entries (xz, lz4 and zstd)

### DIFF
--- a/bin/cat.go
+++ b/bin/cat.go
@@ -69,6 +69,7 @@ func doCat() {
 
 	journal, err := parser.OpenFile(reader)
 	kingpin.FatalIfError(err, "Can not open filesystem")
+	defer journal.Close()
 
 	if *cat_command_raw {
 		journal.RawLogs = true

--- a/bin/info.go
+++ b/bin/info.go
@@ -24,6 +24,7 @@ func doInfo() {
 
 	journal, err := parser.OpenFile(reader)
 	kingpin.FatalIfError(err, "Can not open filesystem")
+	defer journal.Close()
 
 	fmt.Printf("%v\n", journal.DebugString())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/Velocidex/go-journalctl
 
-go 1.22.2
+go 1.24
 
 require (
 	github.com/Velocidex/ordereddict v0.0.0-20230909174157-2aa49cc5d11d
 	github.com/alecthomas/kingpin/v2 v2.4.0
+	github.com/klauspost/compress v1.18.6
 	www.velocidex.com/golang/go-ntfs v0.2.0
 )
 
@@ -14,6 +15,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,12 +19,16 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
+github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=

--- a/parser/compress.go
+++ b/parser/compress.go
@@ -1,12 +1,15 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
+	"github.com/ulikunitz/xz"
 )
 
 // Compression flag bits in ObjectHeader.flags(); see OBJECT_COMPRESSED_* in
@@ -61,15 +64,30 @@ func decompressLZ4(compressed []byte) ([]byte, error) {
 	return dst[:n], nil
 }
 
+// XZ (oldest journals, systemd < 216): payload is a raw XZ stream.
+func decompressXZ(compressed []byte) ([]byte, error) {
+	r, err := xz.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return nil, fmt.Errorf("xz: failed to init reader: %w", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("xz: failed to decompress: %w", err)
+	}
+	return out, nil
+}
+
 // decompressPayload decompresses a DATA object payload if the object flags
 // indicate compression, then returns the raw bytes.
 func decompressPayload(flags byte, compressed []byte) ([]byte, error) {
 	switch {
+	case flags&objectCompressedXZ != 0:
+		return decompressXZ(compressed)
 	case flags&objectCompressedZSTD != 0:
 		return decompressZSTD(compressed)
 	case flags&objectCompressedLZ4 != 0:
 		return decompressLZ4(compressed)
 	default:
-		return nil, fmt.Errorf("lz4: unknown compression flags: 0x%02x", flags)
+		return nil, fmt.Errorf("unknown compression flags: 0x%02x", flags)
 	}
 }

--- a/parser/compress.go
+++ b/parser/compress.go
@@ -1,0 +1,75 @@
+package parser
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+)
+
+// Compression flag bits in ObjectHeader.flags(); see OBJECT_COMPRESSED_* in
+// https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-journal/journal-def.h
+const (
+	objectCompressedXZ   = 0x01
+	objectCompressedLZ4  = 0x02
+	objectCompressedZSTD = 0x04
+)
+
+var (
+	zstd_decoder      *zstd.Decoder
+	zstd_decoder_once sync.Once
+)
+
+func getZSTDDecoder() (*zstd.Decoder, error) {
+	var err error
+	zstd_decoder_once.Do(func() {
+		zstd_decoder, err = zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
+	})
+	return zstd_decoder, err
+}
+
+// ZSTD: payload is a raw ZSTD frame (starts with magic 0xFD2FB528)
+func decompressZSTD(compressed []byte) ([]byte, error) {
+	if len(compressed) < 4 {
+		return nil, fmt.Errorf("zstd: payload too short (%d bytes)", len(compressed))
+	}
+	dec, err := getZSTDDecoder()
+	if err != nil {
+		return nil, fmt.Errorf("zstd: failed to init decoder: %w", err)
+	}
+	out, err := dec.DecodeAll(compressed, nil)
+	if err != nil {
+		return nil, fmt.Errorf("zstd: failed to decompress: %w", err)
+	}
+	return out, nil
+}
+
+// LZ4 (older journals): payload is a raw LZ4 block prefixed by a
+// little-endian uint64 giving the original (decompressed) size.
+func decompressLZ4(compressed []byte) ([]byte, error) {
+	if len(compressed) < 8 {
+		return nil, fmt.Errorf("lz4: payload too short (%d bytes)", len(compressed))
+	}
+	orig_size := int(binary.LittleEndian.Uint64(compressed[:8]))
+	dst := make([]byte, orig_size)
+	n, err := lz4.UncompressBlock(compressed[8:], dst)
+	if err != nil {
+		return nil, fmt.Errorf("lz4: failed to decompress: %w", err)
+	}
+	return dst[:n], nil
+}
+
+// decompressPayload decompresses a DATA object payload if the object flags
+// indicate compression, then returns the raw bytes.
+func decompressPayload(flags byte, compressed []byte) ([]byte, error) {
+	switch {
+	case flags&objectCompressedZSTD != 0:
+		return decompressZSTD(compressed)
+	case flags&objectCompressedLZ4 != 0:
+		return decompressLZ4(compressed)
+	default:
+		return nil, fmt.Errorf("lz4: unknown compression flags: 0x%02x", flags)
+	}
+}

--- a/parser/compress.go
+++ b/parser/compress.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"sync"
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -20,25 +19,25 @@ const (
 	objectCompressedZSTD = 0x04
 )
 
-var (
-	zstd_decoder      *zstd.Decoder
-	zstd_decoder_once sync.Once
-)
+func (self *JournalFile) getZSTDDecoder() (res *zstd.Decoder, err error) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
 
-func getZSTDDecoder() (*zstd.Decoder, error) {
-	var err error
-	zstd_decoder_once.Do(func() {
-		zstd_decoder, err = zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
-	})
-	return zstd_decoder, err
+	if self.zstd_decoder != nil {
+		return self.zstd_decoder, nil
+	}
+
+	self.zstd_decoder, err = zstd.NewReader(
+		nil, zstd.WithDecoderConcurrency(0))
+	return self.zstd_decoder, err
 }
 
 // ZSTD: payload is a raw ZSTD frame (starts with magic 0xFD2FB528)
-func decompressZSTD(compressed []byte) ([]byte, error) {
+func decompressZSTD(ctx *JournalFile, compressed []byte) ([]byte, error) {
 	if len(compressed) < 4 {
 		return nil, fmt.Errorf("zstd: payload too short (%d bytes)", len(compressed))
 	}
-	dec, err := getZSTDDecoder()
+	dec, err := ctx.getZSTDDecoder()
 	if err != nil {
 		return nil, fmt.Errorf("zstd: failed to init decoder: %w", err)
 	}
@@ -79,12 +78,13 @@ func decompressXZ(compressed []byte) ([]byte, error) {
 
 // decompressPayload decompresses a DATA object payload if the object flags
 // indicate compression, then returns the raw bytes.
-func decompressPayload(flags byte, compressed []byte) ([]byte, error) {
+func decompressPayload(
+	ctx *JournalFile, flags byte, compressed []byte) ([]byte, error) {
 	switch {
 	case flags&objectCompressedXZ != 0:
 		return decompressXZ(compressed)
 	case flags&objectCompressedZSTD != 0:
-		return decompressZSTD(compressed)
+		return decompressZSTD(ctx, compressed)
 	case flags&objectCompressedLZ4 != 0:
 		return decompressLZ4(compressed)
 	default:

--- a/parser/entry.go
+++ b/parser/entry.go
@@ -112,6 +112,21 @@ func (self *EntryObject) GetRaw(ctx *JournalFile, size int64) *ordereddict.Dict 
 	return result
 }
 
+func read_payload(reader interface {
+	ReadAt([]byte, int64) (int, error)
+}, offset, length int64, flags byte) string {
+	if flags&(objectCompressedXZ|objectCompressedLZ4|objectCompressedZSTD) != 0 {
+		compressed := make([]byte, length)
+		n, err := reader.ReadAt(compressed, offset)
+		if err == nil || err.Error() == "EOF" {
+			if decompressed, err2 := decompressPayload(flags, compressed[:n]); err2 == nil {
+				return string(decompressed)
+			}
+		}
+	}
+	return ParseString(reader, offset, length)
+}
+
 func (self *EntryObject) items_compact(ctx *JournalFile, size int64) []string {
 	var res []string
 
@@ -135,11 +150,10 @@ func (self *EntryObject) items_compact(ctx *JournalFile, size int64) []string {
 			payload_len := obj_size - int64(data_obj.Size()) -
 				self.Profile.Off_CompatDataObject_payload
 
-			// Start reading after the object header
-			payload := ParseString(self.Reader,
-				obj_offset+int64(data_obj.Size())+
-					self.Profile.Off_CompatDataObject_payload,
-				payload_len)
+			payload_offset := obj_offset + int64(data_obj.Size()) +
+				self.Profile.Off_CompatDataObject_payload
+
+			payload := read_payload(self.Reader, payload_offset, payload_len, data_obj.flags())
 
 			res = append(res, payload)
 		}
@@ -172,11 +186,10 @@ func (self *EntryObject) items_regular(ctx *JournalFile, size int64) []string {
 			payload_len := obj_size - int64(data_obj.Size()) -
 				self.Profile.Off_DataObject_payload
 
-			// Start reading after the object header
-			payload := ParseString(self.Reader,
-				obj_offset+int64(data_obj.Size())+
-					self.Profile.Off_DataObject_payload,
-				payload_len)
+			payload_offset := obj_offset + int64(data_obj.Size()) +
+				self.Profile.Off_DataObject_payload
+
+			payload := read_payload(self.Reader, payload_offset, payload_len, data_obj.flags())
 
 			res = append(res, payload)
 		}

--- a/parser/entry.go
+++ b/parser/entry.go
@@ -112,14 +112,15 @@ func (self *EntryObject) GetRaw(ctx *JournalFile, size int64) *ordereddict.Dict 
 	return result
 }
 
-func read_payload(reader interface {
+func (self *JournalFile) read_payload(reader interface {
 	ReadAt([]byte, int64) (int, error)
 }, offset, length int64, flags byte) string {
 	if flags&(objectCompressedXZ|objectCompressedLZ4|objectCompressedZSTD) != 0 {
 		compressed := make([]byte, length)
 		n, err := reader.ReadAt(compressed, offset)
 		if err == nil || err.Error() == "EOF" {
-			if decompressed, err2 := decompressPayload(flags, compressed[:n]); err2 == nil {
+			if decompressed, err2 := decompressPayload(
+				self, flags, compressed[:n]); err2 == nil {
 				return string(decompressed)
 			}
 		}
@@ -153,7 +154,8 @@ func (self *EntryObject) items_compact(ctx *JournalFile, size int64) []string {
 			payload_offset := obj_offset + int64(data_obj.Size()) +
 				self.Profile.Off_CompatDataObject_payload
 
-			payload := read_payload(self.Reader, payload_offset, payload_len, data_obj.flags())
+			payload := ctx.read_payload(
+				self.Reader, payload_offset, payload_len, data_obj.flags())
 
 			res = append(res, payload)
 		}
@@ -189,7 +191,8 @@ func (self *EntryObject) items_regular(ctx *JournalFile, size int64) []string {
 			payload_offset := obj_offset + int64(data_obj.Size()) +
 				self.Profile.Off_DataObject_payload
 
-			payload := read_payload(self.Reader, payload_offset, payload_len, data_obj.flags())
+			payload := ctx.read_payload(
+				self.Reader, payload_offset, payload_len, data_obj.flags())
 
 			res = append(res, payload)
 		}

--- a/parser/open.go
+++ b/parser/open.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/Velocidex/ordereddict"
+	"github.com/klauspost/compress/zstd"
 )
 
 type JournalFile struct {
@@ -26,6 +28,19 @@ type JournalFile struct {
 	MaxTime time.Time
 
 	RawLogs bool
+
+	mu           sync.Mutex
+	zstd_decoder *zstd.Decoder
+}
+
+func (self *JournalFile) Close() {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	if self.zstd_decoder != nil {
+		self.zstd_decoder.Close()
+	}
+	self.zstd_decoder = nil
 }
 
 func (self *JournalFile) DebugString() string {


### PR DESCRIPTION
Some text, especially long messages, get compressed in the journal. The current implementation tries to parse the resulting binary data as strings.

This merge request implements support for ZSTD and LZ4. ZSTD is the currently used compression, and LZ4 was previously used (up until 2014, I believe). Before that XZ may have been used, but I have not added support for that.

Dependencies used are the same as elsewhere in Velocidex, albeit with the latest versions in case there are relevant important (security) fixes. Feel free to downgrade to match versions used in other Velocidex libraries.

Compressed log messages can easily be generated with piping long strings into `systemd-cat`. The journal files in the attached zip file demonstrates compressed data in LZ4 (Ubuntu 20.04) and ZSTD (Ubuntu 24.04). Parsing these files with `go-journalctl cat` will demonstrate an empty MESSAGE and binary data in Item24, and a long "XXXXX[…]" MESSAGE in this merge request's verison.

[journals.zip](https://github.com/user-attachments/files/28682941/journals.zip)